### PR TITLE
error-avoiding when a certain run isn't found

### DIFF
--- a/01-import_and_filter.py
+++ b/01-import_and_filter.py
@@ -31,12 +31,6 @@ def run_filter(subject):
     n_raws = 0
     for run in config.runs:
 
-        # read bad channels for run from config
-        if run:
-            bads = config.bads[subject][run]
-        else:
-            bads = config.bads[subject]
-
         extension = run + '_raw'
         raw_fname_in = op.join(meg_subject_dir,
                                config.base_fname.format(**locals()))
@@ -53,6 +47,12 @@ def run_filter(subject):
                  (raw_fname_in, subject))
             continue
 
+            # read bad channels for run from config
+        if run:
+            bads = config.bads[subject][run]
+        else:
+            bads = config.bads[subject]
+            
         raw = mne.io.read_raw_fif(raw_fname_in,
                                   allow_maxshield=config.allow_maxshield,
                                   preload=True, verbose='error')


### PR DESCRIPTION
The original code threw a run when a run didn't exist in my folder.
  File "C:/Users/Repositories/CogBrainDyn_MEG_Pipeline/01-import_and_filter.py", line 35, in run_filter
    bads = config.bads[subject][run]
KeyError: 'Run03'